### PR TITLE
expect(count, stubfn)

### DIFF
--- a/lib/gently/gently.js
+++ b/lib/gently/gently.js
@@ -48,10 +48,10 @@ Gently.prototype.hijack = function(realRequire) {
 };
 
 Gently.prototype.expect = function(obj, method, count, stubFn) {
-  if (typeof obj != 'function' && typeof obj != 'object') {
+  if (typeof obj != 'function' && typeof obj != 'object' && typeof obj != 'number') {
     throw new Error
       ( 'Bad 1st argument for gently.expect(), '
-      + 'object or function expected, got: '+(typeof obj)
+      + 'object, function, or number expected, got: '+(typeof obj)
       );
   } else if (typeof obj == 'function' && (typeof method != 'string')) {
     // expect(stubFn) interface

--- a/test/simple/test-gently.js
+++ b/test/simple/test-gently.js
@@ -20,7 +20,7 @@ test(function expectBadArgs() {
     gently.expect(BAD_ARG);
     assert.ok(false, 'throw needs to happen');
   } catch (e) {
-    assert.equal(e.message, 'Bad 1st argument for gently.expect(), object or function expected, got: '+(typeof BAD_ARG));
+    assert.equal(e.message, 'Bad 1st argument for gently.expect(), object, function, or number expected, got: '+(typeof BAD_ARG));
   }
 });
 
@@ -102,6 +102,18 @@ test(function expectClosure() {
   };
   assert.equal(fn.apply(SELF, [1, 2]), 23);
   assert.equal(stubFnCalled, 1);
+});
+
+test(function expectClosureCount() {
+  var stubFnCalled = 0;
+  function closureFn() {stubFnCalled++};
+
+  var fn = gently.expect(2, closureFn);
+  assert.equal(gently.expectations.length, 2);
+  fn();
+  assert.equal(gently.expectations.length, 1);
+  fn();
+  assert.equal(stubFnCalled, 2);
 });
 
 test(function restore() {


### PR DESCRIPTION
Hello,

I like your library here! I went to use the method gently.expect(count, fn), and realized that the check at the beginning of the expect function disallows anything other than obj and function as the first parameter.

This may very well not be the exact fix you're looking for, but I've added a simple test and an allowance for typeof obj == 'number' at the top of expect(). I can't help but think that the whole argument parsing section of that method could be rewritten a little cleaner, but I wanted to change as little as possible and make it work.

Hope this works, and I appreciate all of your dev and writing for node!

-jer
