### PR TITLE
Make gently and vows play nicely

### DIFF
--- a/lib/gently/gently.js
+++ b/lib/gently/gently.js
@@ -1,11 +1,11 @@
 var path = require('path');
 
-function Gently() {
+function Gently(manualMode) {
   this.expectations = [];
   this.hijacked = {};
 
   var self = this;
-  process.addListener('exit', function() {
+  !manualMode && process.addListener('exit', function() {
     self.verify('process exit');
   });
 };
@@ -104,6 +104,8 @@ Gently.prototype.restore = function(obj, method) {
 };
 
 Gently.prototype.verify = function(msg) {
+  if(this.stubAssertion) throw this.stubAssertion;
+
   if (!this.expectations.length) {
     return;
   }
@@ -130,7 +132,16 @@ Gently.prototype._stubFn = function(self, obj, method, name, args) {
   }
 
   if (expectation.stubFn) {
-    return expectation.stubFn.apply(self, args);
+	try {
+      return expectation.stubFn.apply(self, args);
+	}
+	catch(e) {
+	  // If this is an AssertionError from the stub, we stash it for later.
+	  if(e instanceof require("assert").AssertionError)
+	    this.stubAssertion = e;
+	  else
+		throw e;
+	}
   }
 };
 


### PR DESCRIPTION
Hi Felix,

Would be great if you could review some very straightforward changes to Gently. These changes are entirely to make it play nicely with Vows testing framework.

The first problem happens if you stub a function with expect(), try to make assertions in this stub, and the call this stub in a vows topic. If one of the assertions fail in the stubbed function you get very bizarre errors like this:

```
node.js:68
      throw e; // process.nextTick error, or 'error' event on first tick

<error: TypeError: Cannot call method 'match' of undefined>
    at Test.<anonymous> (/home/sam/workspace/funwithgently/test.js:17:12)
    at Gently._stubFn (/home/sam/workspace/funwithgently/gently.js:136:33)
    at Test.delegate [as echo] (/home/sam/workspace/funwithgently/gently.js:84:17)
    at Object.<anonymous> (/home/sam/workspace/funwithgently/test.js:20:11)
    at run (/usr/local/lib/node/.npm/vows/0.5.6/package/lib/vows/suite.js:130:31)
    at EventEmitter.<anonymous> (/usr/local/lib/node/.npm/vows/0.5.6/package/lib/vows/suite.js:203:40)
    at EventEmitter.emit (events.js:59:20)
    at Array.<anonymous> (/usr/local/lib/node/.npm/vows/0.5.6/package/lib/vows/suite.js:152:58)
    at EventEmitter._tickCallback (node.js:60:24)
```

The reason this happens (as far as I can guess, it's actually a pretty cryptic error to me), is because vows is not designed to handle assertions occurring inside a topic function. Rather, assertions, and indeed any other kind of exception, are supposed to happen inside an actual vow.

The changes I am submitting will trap any potential AssertionError's that occur in the stubbed function, save them, and then throw them properly inside verify().

This means you can write some vows like so:

```
var Gently = require("gently"),
    assert = require("assert"),
    vows = require("vows");

function Test() {
    this.echo = function(msg) {
        console.log(msg);
    };
};

vows.describe("Test").addBatch({
    "Test.echo": {
        topic: function() {
            var myTest = new Test();
            myTest._gently = new Gently(true);
            myTest._gently.expect(myTest, "echo", function(msg) {
                assert.equal(msg, "hello");
            });

            myTest.echo("Bonjour!");

            return myTest;
        },

        "is called": function(myTest) {
            myTest._gently.verify();
        }
    }
}).export(module);
```

When you run this, you get a proper vows scenario in which it will catch the AssertionError, and display an output like this:

```
♢ Test

  Test.echo
    ✗ is called
      » expected 'hello',
    got  'Bonjour!' (==) // test.js:17

✗ Broken » 1 broken (0.006s)
```

I think you can agree this is pretty sexy, it actually scans the exception callstack and still correctly reports the assertion exactly where it's happening on line 17, which is inside the stubbed expect() function, defined in the topic itself.

The other change I made was to add a formal way to tell Gently not to run verify() on process.on("exit"). This is so you can run verify() manually in Vows. Vows doesn't really have a formal teardown process for test cases, so if a method isn't called, it will report the error inside the test case, and then report it again when vows exits. This is because there's no elegant/formal way to restore() the stubbed method in the event of a verify() failure.
