### PR TITLE
Autorestore functions when all the expectations are satisfied

### DIFF
--- a/lib/gently/gently.js
+++ b/lib/gently/gently.js
@@ -75,9 +75,7 @@ Gently.prototype.expect = function(obj, method, count, stubFn) {
   }
 
   var name = this._name(obj, method, stubFn);
-  while (count-- > 0) {
-    this.expectations.push({obj: obj, method: method, stubFn: stubFn, name: name});
-  }
+  this.expectations.push({obj: obj, method: method, stubFn: stubFn, name: name, count: count});
 
   var self = this;
   function delegate() {
@@ -119,14 +117,31 @@ Gently.prototype.verify = function(msg) {
 };
 
 Gently.prototype._stubFn = function(self, obj, method, name, args) {
-  var expectation = this.expectations.shift();
+  var expectation = this.expectations[0], obj, method;
+
   if (!expectation) {
     throw new Error('Unexpected call to '+name+', no call was expected');
   }
 
   if (expectation.obj !== obj || expectation.method !== method) {
-    this.expectations.unshift(expectation);
     throw new Error('Unexpected call to '+name+', expected call to '+ expectation.name);
+  }
+
+  expectation.count -= 1;
+  if (expectation.count === 0) {
+    this.expectations.shift();
+
+    // restore original if not a closure
+    obj = expectation.obj;
+    method = expectation.method;
+    if (obj !== null && method !== null) {
+      if (typeof obj[method]._original !== 'undefined') {
+        obj[method] = obj[method]._original;
+        delete obj[method]._original;
+      } else {
+        delete obj[method];
+      }
+    }
   }
 
   if (expectation.stubFn) {

--- a/test/simple/test-gently.js
+++ b/test/simple/test-gently.js
@@ -51,13 +51,13 @@ test(function expectObjMethod() {
 
   (function testAddTwo() {
     gently.expect(OBJ, 'foo', 2, stubFn);
-    assert.equal(gently.expectations.length, 3);
+    assert.equal(gently.expectations.length, 2);
     assert.strictEqual(OBJ.foo._original, original);
   })();
 
   (function testAddOneWithoutMock() {
     gently.expect(OBJ, 'foo');
-    assert.equal(gently.expectations.length, 4);
+    assert.equal(gently.expectations.length, 3);
   })();
 
   var stubFnCalled = 0, SELF = {};
@@ -109,7 +109,7 @@ test(function expectClosureCount() {
   function closureFn() {stubFnCalled++};
 
   var fn = gently.expect(2, closureFn);
-  assert.equal(gently.expectations.length, 2);
+  assert.equal(gently.expectations.length, 1);
   fn();
   assert.equal(gently.expectations.length, 1);
   fn();
@@ -143,7 +143,7 @@ test(function restore() {
 
 test(function _stubFn() {
   var OBJ1 = {toString: function() {return '[OBJ 1]'}}
-    , OBJ2 = {toString: function() {return '[OBJ 2]'}}
+    , OBJ2 = {toString: function() {return '[OBJ 2]'}, foo: function () {return 'bar';}}
     , SELF = {};
 
   gently.expect(OBJ1, 'foo', function(x) {
@@ -152,6 +152,18 @@ test(function _stubFn() {
   });
 
   assert.equal(gently._stubFn(SELF, OBJ1, 'foo', 'dummy_name', [5]), 10);
+
+  (function testAutorestore() {
+    assert.equal(OBJ2.foo(), 'bar');
+
+    gently.expect(OBJ2, 'foo', function() {
+      return 'stubbed foo';
+    });
+
+    assert.equal(gently._stubFn(SELF, OBJ2, 'foo', 'dummy_name', []), 'stubbed foo');
+    assert.equal(OBJ2.foo(), 'bar');
+    assert.deepEqual(gently.expectations, []);
+  })();
 
   (function testNoMoreCallExpected() {
     try {


### PR DESCRIPTION
Sometimes its annoying to restore functions manually.

With this commit, once all the expectations are satisfied, the original method is restored and cleaned.

I added some tests.
