### PR TITLE
don't autorestore if there are more expectations

### DIFF
--- a/lib/gently/gently.js
+++ b/lib/gently/gently.js
@@ -131,10 +131,12 @@ Gently.prototype._stubFn = function(self, obj, method, name, args) {
   if (expectation.count === 0) {
     this.expectations.shift();
 
-    // restore original if not a closure
-    obj = expectation.obj;
-    method = expectation.method;
-    if (obj !== null && method !== null) {
+    // autorestore original if its not a closure
+    // and no more expectations on that object
+    has_more_expectations = this.expectations.reduce(function (memo, expectation) {
+      return memo || (expectation.obj === obj && expectation.method === method);
+    }, false);
+    if (obj !== null && method !== null && !has_more_expectations) {
       if (typeof obj[method]._original !== 'undefined') {
         obj[method] = obj[method]._original;
         delete obj[method]._original;

--- a/test/simple/test-gently.js
+++ b/test/simple/test-gently.js
@@ -160,7 +160,12 @@ test(function _stubFn() {
       return 'stubbed foo';
     });
 
+    gently.expect(OBJ2, 'foo', function() {
+      return "didn't restore yet";
+    });
+
     assert.equal(gently._stubFn(SELF, OBJ2, 'foo', 'dummy_name', []), 'stubbed foo');
+    assert.equal(gently._stubFn(SELF, OBJ2, 'foo', 'dummy_name', []), "didn't restore yet");
     assert.equal(OBJ2.foo(), 'bar');
     assert.deepEqual(gently.expectations, []);
   })();


### PR DESCRIPTION
Sorry felix, I know you are working on `node-fake` but I still use gently to test all my modules and applications.
I introduced a little bug on my last commit, this pull fixes it.

Use case:

``` javascript
 var documents = [ {activate_code: 123, name: 'asd', email: 'a@b.com'}
                      , {activate_code: 456, name: 'qwe', email: 'c@d.com'}
                      , {activate_code: 789, name: 'zxc', email: 'e@f.com'}
                      ]
        , callback;

      stub_mailer();

      documents.forEach(function (document) {
        gently.expect(mailer, 'smtp', function (options) {
          assert.equal(options.to, document.email);
          assert.equal(options.from, "noreply@zpeaker.com");
        });
      });

      // BUG: When the first expectation is met, the `smtp` method was autorestored

      callback = gently.expect(function () {});

      user.afterInsert(documents, callback);
```
