### PR TITLE
Add support for expecting a method to *not* be called.

### DIFF
--- a/lib/gently/gently.js
+++ b/lib/gently/gently.js
@@ -106,7 +106,21 @@ Gently.prototype.verify = function(msg) {
     return;
   }
 
-  var expectation = this.expectations[0];
+  var validExpectations = [];
+  for (var i = 0, l = this.expectations.length; i < l; i++) {
+    var expectation = this.expectations[i];
+
+    if (expectation.count > 0) {
+      validExpectations.push(expectation);
+    }
+  }
+
+  if (!validExpectations.length) {
+    return;
+  }
+
+  var expectation = validExpectations[0];
+
   throw new Error
     ( 'Expected call to '+expectation.name+' did not happen'
     + ( (msg)

--- a/test/simple/test-gently.js
+++ b/test/simple/test-gently.js
@@ -334,3 +334,15 @@ test(function _name() {
     assert.equal(gently._name(null, null, myClosure), '>> '+myClosure.toString()+' <<');
   })();
 });
+
+test(function verifyExpectNone() {
+  var OBJ = {toString: function() {return '[OBJ]'}};
+  gently.verify();
+
+  gently.expect(OBJ, 'foo', 0);
+  try {
+    gently.verify();
+  } catch (e) {
+    assert.fail('Exception should not have been thrown');
+  }
+});


### PR DESCRIPTION
This used to work, but it seems to have stopped at some point. What seems to be the problem is gently is treating the existence of an expectation as proof of a failure, but what we really care about is the existence of an expectation whose count is > 0. For example if I were to do:

```
gently.expect(someObject, "someFunction", 0);
```

To be sure that someObject.someFunction is never called, in the event that everything is working as intended and someObject.someFunction is not invoked, the expectation would still exist, and thus verify call would fail. After this patch, verify will only fail if expectations with a count > 0 still exist.

This time including a test case which I should've done to begin with, sorry about that ;).
