### PR TITLE
Added the option expect(obj, stubFn)

### DIFF
--- a/lib/gently/gently.js
+++ b/lib/gently/gently.js
@@ -53,11 +53,15 @@ Gently.prototype.expect = function(obj, method, count, stubFn) {
       ( 'Bad 1st argument for gently.expect(), '
       + 'object, function, or number expected, got: '+(typeof obj)
       );
-  } else if (typeof obj == 'function' && (typeof method != 'string')) {
+  } else if (typeof obj == 'function' && typeof method == 'undefined') {
     // expect(stubFn) interface
     stubFn = obj;
     obj = null;
     method = null;
+    count = 1;
+  } else if (typeof obj === 'function' && typeof method === 'function') {
+    // expect(obj, stubFn) interface
+    stubFn = method;
     count = 1;
   } else if (typeof method == 'function') {
     // expect(count, stubFn) interface


### PR DESCRIPTION
Added the option expect(obj, stubFn), very useful for modules that are a function (request for instance).
`gently.expect(gently.hijacked.request, function (...) {});
