### PR TITLE
Added repository field to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "lib": "./lib/gently"
   },
   "main": "./lib/gently/index",
+  "repository":{
+    "type": "git",
+    "url": "https://github.com/felixge/node-gently.git"
+  },
   "dependencies": {},
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
This is to get rid of a pesky warning from npm:

```
npm WARN package.json gently@0.9.2 No repository field.
```
