### PR TITLE
Show caller information in gently verify

### DIFF
--- a/lib/gently/gently.js
+++ b/lib/gently/gently.js
@@ -2,25 +2,25 @@ var path = require('path');
 
 function Gently() {
   this.expectations = [];
-  this.hijacked = {};
+  this.hijacked     = {};
 
   var self = this;
   process.addListener('exit', function() {
     self.verify('process exit');
   });
-};
+}
 module.exports = Gently;
 
 Gently.prototype.stub = function(location, exportsName) {
   function Stub() {
     return Stub['new'].apply(this, arguments);
-  };
+  }
 
-  Stub['new'] = function () {};
+  Stub['new'] = function() {};
 
-  var stubName = 'require('+JSON.stringify(location)+')';
+  var stubName = 'require(' + JSON.stringify(location) + ')';
   if (exportsName) {
-    stubName += '.'+exportsName;
+    stubName += '.' + exportsName;
   }
 
   Stub.prototype.toString = Stub.toString = function() {
@@ -41,43 +41,55 @@ Gently.prototype.stub = function(location, exportsName) {
 Gently.prototype.hijack = function(realRequire) {
   var self = this;
   return function(location) {
-    return self.hijacked[location] = (self.hijacked[location])
-      ? self.hijacked[location]
-      : realRequire(location);
+    if (!self.hijacked[location]) {
+      self.hijacked[location] = realRequire(location);
+    }
+
+    return self.hijacked[location];
   };
 };
 
 Gently.prototype.expect = function(obj, method, count, stubFn) {
   if (typeof obj != 'function' && typeof obj != 'object' && typeof obj != 'number') {
-    throw new Error
-      ( 'Bad 1st argument for gently.expect(), '
-      + 'object, function, or number expected, got: '+(typeof obj)
-      );
+    var eMsg = '';
+
+    eMsg += 'Bad 1st argument for gently.expect(), ';
+    eMsg += 'object, function, or number expected, got: ';
+    eMsg += (typeof obj);
+
+    throw new Error(eMsg);
   } else if (typeof obj == 'function' && (typeof method != 'string')) {
     // expect(stubFn) interface
     stubFn = obj;
-    obj = null;
+    obj    = null;
     method = null;
-    count = 1;
+    count  = 1;
   } else if (typeof method == 'function') {
     // expect(count, stubFn) interface
-    count = obj;
+    count  = obj;
     stubFn = method;
-    obj = null;
+    obj    = null;
     method = null;
   } else if (typeof count == 'function') {
     // expect(obj, method, stubFn) interface
     stubFn = count;
-    count = 1;
+    count  = 1;
   } else if (count === undefined) {
     // expect(obj, method) interface
     count = 1;
   }
 
   var name = this._name(obj, method, stubFn);
-  this.expectations.push({obj: obj, method: method, stubFn: stubFn, name: name, count: count});
+  this.expectations.push({
+    obj    : obj,
+    method : method,
+    stubFn : stubFn,
+    name   : name,
+    count  : count,
+  });
 
   var self = this;
+
   function delegate() {
     return self._stubFn(this, obj, method, name, Array.prototype.slice.call(arguments));
   }
@@ -86,17 +98,15 @@ Gently.prototype.expect = function(obj, method, count, stubFn) {
     return delegate;
   }
 
-  var original = (obj[method])
-    ? obj[method]._original || obj[method]
-    : undefined;
+  var original = (obj[method]) ? obj[method]._original || obj[method] : undefined;
 
   obj[method] = delegate;
-  return obj[method]._original = original;
+  return (obj[method]._original = original);
 };
 
 Gently.prototype.restore = function(obj, method) {
   if (!obj[method] || !obj[method]._original) {
-    throw new Error(this._name(obj, method)+' is not gently stubbed');
+    throw new Error(this._name(obj, method) + ' is not gently stubbed');
   }
   obj[method] = obj[method]._original;
 };
@@ -121,26 +131,25 @@ Gently.prototype.verify = function(msg) {
     return;
   }
 
-  var expectation = validExpectations[0];
+  var firstExpectation = validExpectations[0];
 
-  throw new Error
-    ( 'Expected call to '+expectation.name+' did not happen'
-    + ( (msg)
-        ? ' ('+msg+')'
-        : ''
-      )
-    );
+  var eMsg = '';
+  eMsg += 'Expected call to ' + firstExpectation.name + ' did not happen';
+  if (msg) {
+    eMsg += ' (' + msg + ')';
+  }
+  throw new Error(eMsg);
 };
 
 Gently.prototype._stubFn = function(self, obj, method, name, args) {
-  var expectation = this.expectations[0], obj, method;
+  var expectation = this.expectations[0];
 
   if (!expectation) {
-    throw new Error('Unexpected call to '+name+', no call was expected');
+    throw new Error('Unexpected call to ' + name + ', no call was expected');
   }
 
   if (expectation.obj !== obj || expectation.method !== method) {
-    throw new Error('Unexpected call to '+name+', expected call to '+ expectation.name);
+    throw new Error('Unexpected call to ' + name + ', expected call to ' + expectation.name);
   }
 
   expectation.count -= 1;
@@ -149,7 +158,7 @@ Gently.prototype._stubFn = function(self, obj, method, name, args) {
 
     // autorestore original if its not a closure
     // and no more expectations on that object
-    var has_more_expectations = this.expectations.reduce(function (memo, expectation) {
+    var has_more_expectations = this.expectations.reduce(function(memo, expectation) {
       return memo || (expectation.obj === obj && expectation.method === method);
     }, false);
     if (obj !== null && method !== null && !has_more_expectations) {
@@ -171,14 +180,14 @@ Gently.prototype._name = function(obj, method, stubFn) {
   if (obj) {
     var objectName = obj.toString();
     if (objectName == '[object Object]' && obj.constructor.name) {
-      objectName = '['+obj.constructor.name+']';
+      objectName = '[' + obj.constructor.name + ']';
     }
-    return (objectName)+'.'+method+'()';
+    return (objectName) + '.' + method + '()';
   }
 
   if (stubFn.name) {
-    return stubFn.name+'()';
+    return stubFn.name + '()';
   }
 
-  return '>> '+stubFn.toString()+' <<';
+  return '>> ' + stubFn.toString() + ' <<';
 };

--- a/lib/gently/gently.js
+++ b/lib/gently/gently.js
@@ -50,6 +50,9 @@ Gently.prototype.hijack = function(realRequire) {
 };
 
 Gently.prototype.expect = function(obj, method, count, stubFn) {
+  var stackError = new Error();
+  var caller     = stackError.stack.split('\n')[2].trim();
+
   if (typeof obj != 'function' && typeof obj != 'object' && typeof obj != 'number') {
     var eMsg = '';
 
@@ -86,6 +89,7 @@ Gently.prototype.expect = function(obj, method, count, stubFn) {
     stubFn : stubFn,
     name   : name,
     count  : count,
+    caller : caller
   });
 
   var self = this;
@@ -135,6 +139,9 @@ Gently.prototype.verify = function(msg) {
 
   var eMsg = '';
   eMsg += 'Expected call to ' + firstExpectation.name + ' did not happen';
+  if (firstExpectation.caller) {
+    eMsg += ' ' + firstExpectation.caller;
+  }
   if (msg) {
     eMsg += ' (' + msg + ')';
   }

--- a/test/common.js
+++ b/test/common.js
@@ -1,6 +1,8 @@
 var path = require('path')
-  , sys = require('sys');
+  , util = require('util');
 
-global.puts = sys.puts;
-global.p = function() {sys.error(sys.inspect.apply(null, arguments))};;
+global.puts = console.log;
+global.p = function() {
+  console.error(util.inspect.apply(null, arguments));
+};
 global.assert = require('assert');

--- a/test/common.js
+++ b/test/common.js
@@ -1,8 +1,6 @@
 var path = require('path')
   , sys = require('sys');
 
-require.paths.unshift(path.dirname(__dirname)+'/lib');
-
 global.puts = sys.puts;
 global.p = function() {sys.error(sys.inspect.apply(null, arguments))};;
 global.assert = require('assert');

--- a/test/simple/test-gently.js
+++ b/test/simple/test-gently.js
@@ -1,5 +1,5 @@
 require('../common');
-var Gently = require('gently')
+var Gently = require('../..')
   , gently;
 
 function test(test) {

--- a/test/simple/test-gently.js
+++ b/test/simple/test-gently.js
@@ -280,7 +280,7 @@ test(function verify() {
     gently.verify();
     assert.ok(false, 'throw needs to happen');
   } catch (e) {
-    assert.equal(e.message, 'Expected call to [OBJ].foo() did not happen');
+    assert.ok(e.message.match(/Expected call to \[OBJ\].foo\(\) did not happen at/), 'Expected call to [OBJ].foo() did not happen at <location>');
   }
 
   try {

--- a/test/simple/test-gently.js
+++ b/test/simple/test-gently.js
@@ -285,9 +285,9 @@ test(function verify() {
 
   try {
     gently.verify('foo');
-    assert.ok(false, 'throw needs to happen');
+    assert.ok(false, 'throw does not need to happen, as verify() cleared out the expectations');
   } catch (e) {
-    assert.equal(e.message, 'Expected call to [OBJ].foo() did not happen (foo)');
+    assert.equal(e.message, 'throw does not need to happen, as verify() cleared out the expectations');
   }
 });
 


### PR DESCRIPTION
If you have a large test suite, it helps knowing which gently expect went sour.

In order to make this I first had to

 - Make gently's test-suite run again, it relied on some deprecated tech such as `require.paths`
 - Fix the verify test, it was broken in that it wrongfully expected verify to throw an error the second time, even though it did not expect anything after clearing the expectations
 - Fix linting and whitespace issues (okay I didn't *have* to, and the PR would have probably been cleaner had I refrained, but this project needed a facelift badly so I couldn't help myself : )

After this I would also like (someone with admin access) to integrate Travis, so the project won't be left in a broken state again.