### PR TITLE
Make _name() work well with classes

### DIFF
--- a/lib/gently/gently.js
+++ b/lib/gently/gently.js
@@ -185,11 +185,13 @@ Gently.prototype._stubFn = function(self, obj, method, name, args) {
 
 Gently.prototype._name = function(obj, method, stubFn) {
   if (obj) {
-    var objectName = obj.toString();
-    if (objectName == '[object Object]' && obj.constructor.name) {
-      objectName = '[' + obj.constructor.name + ']';
+    let objectName
+    if (typeof obj === 'function' && obj.name) {
+      objectName = obj.name;
+    } else {
+      objectName = obj.toString();
     }
-    return (objectName) + '.' + method + '()';
+    return objectName + '.' + method + '()';
   }
 
   if (stubFn.name) {


### PR DESCRIPTION
Here is the implementation of .functionName in sinon as a reference https://github.com/sinonjs/sinon/blob/c8901e7bdfd95bc34daf509fa3cc56d3100fb206/docs/releases/sinon-1.10.1.js#L446